### PR TITLE
Add options for setting chatgpt-wrapper backend & model

### DIFF
--- a/chatgpt.el
+++ b/chatgpt.el
@@ -23,6 +23,18 @@
   :prefix "chatgpt-"
   :group 'ai)
 
+(defcustom chatgpt-backend "chatgpt-browser"
+  "The backend for ChatGPT.el / chatgpt-wrapper (Options: 'chatgpt-browser',
+'chatgpt-api'. Default: 'chatgpt-browser'."
+  :type 'string
+  :group 'chatgpt)
+
+(defcustom chatgpt-model "default"
+  "The ChatGPT model to use (Options: 'default', 'legacy-paid', 'legacy-free',
+'gpt4'. Default: 'default'."
+  :type 'string
+  :group 'chatgpt)
+
 (defcustom chatgpt-query-format-string-map
   '(("doc" . "Please write the documentation for the following function.\n\n%s")
     ("bug" . "There is a bug in the following function, please help me fix it.\n\n%s")
@@ -229,7 +241,7 @@ users."
       (chatgpt-display))
     (deferred:$
      (deferred:$
-      (epc:call-deferred chatgpt-process 'query (list query))
+      (epc:call-deferred chatgpt-process 'query (list query chatgpt-backend chatgpt-model))
       (eval `(deferred:nextc it
                (lambda (response)
                  (chatgpt--stop-wait ,saved-id)

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -2,7 +2,7 @@
 
 import pkg_resources
 from epc.server import EPCServer
-# Hedge against breaking changes in chatgpt-wrapper
+# Hedge against breaking changes in chatgpt-wrapper >= 0.5.0
 try:
     from chatgpt_wrapper import ChatGPT
     from chatgpt_wrapper.config import Config
@@ -22,7 +22,7 @@ def query(query):
         bot = ChatGPT(config)
         bot.launch_browser()
 
-    # Hedge against more breaking changes in chatgpt-wrapper
+    # Hedge against more breaking changes in chatgpt-wrapper >= 0.5.0
     response = bot.ask(query)
     try:
         success, response, message = response

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -1,30 +1,57 @@
 # chatgpt.py
 
-import pkg_resources
 from epc.server import EPCServer
 # Hedge against breaking changes in chatgpt-wrapper
 try:
-    from chatgpt_wrapper import ChatGPT
     from chatgpt_wrapper.config import Config
+    import chatgpt_wrapper.constants as constants
 except ImportError:
-    from chatgpt_wrapper.backends.browser.chatgpt import ChatGPT
     from chatgpt_wrapper.core.config import Config
+    import chatgpt_wrapper.core.constants as constants
 
 server = EPCServer(('localhost', 0))
 bot = None
 
 @server.register_function
-def query(query):
+def query(query, backend="chatgpt-browser", model="default"):
     global bot
     if bot is None:
         config = Config()
-        config.load_from_file()
-        config.set("browser.debug", False)
-        bot = ChatGPT(config)
-        bot.launch_browser()
+        chatgpt_wrapper_browser_models = list(constants.RENDER_MODELS.keys())
+        chatgpt_wrapper_api_models = list(
+            constants.OPENAPI_CHAT_RENDER_MODELS.keys())
+        if backend == "chatgpt-browser":
+            config.set("backend", backend)
+            if model not in chatgpt_wrapper_browser_models:
+                return (f"ChatGPT.el: Unknown chatgpt-wrapper model '{model}' "
+                   f"for '{backend}' backend. "
+                   f"Options are: {chatgpt_wrapper_browser_models}.")
+            config.set("chat.model", model)
+            # Hedge against breaking changes in chatgpt-wrapper >= 0.7.0
+            try:
+                from chatgpt_wrapper import ChatGPT
+            except ImportError:
+                from chatgpt_wrapper.backends.browser.chatgpt import ChatGPT
+            bot = ChatGPT(config)
+            bot.launch_browser()
+        elif backend == "chatgpt-api":
+            config.set("backend", backend)
+            if model not in chatgpt_wrapper_api_models:
+                return (f"ChatGPT.el: Unknown chatgpt-wrapper model '{model}' "
+                   f"for '{backend}' backend. "
+                   f"Options are: {chatgpt_wrapper_api_models}.")
+            config.set("chat.model", model)
+            # NOTE: This will not retain conversation history in its current
+            # form.
+            # See: https://github.com/mmabrouk/chatgpt-wrapper/issues/285
+            from chatgpt_wrapper import OpenAIAPI
+            bot = OpenAIAPI(config)
+        else:
+            return (f"ChatGPT.el: Unknown chatgpt-wrapper backend: '{backend}'. "
+               f"Options are: 'chatgpt-browser', 'chatgpt-api'.")
 
-    # Hedge against more breaking changes in chatgpt-wrapper
     response = bot.ask(query)
+    # Hedge against more breaking changes in chatgpt-wrapper
     try:
         success, response, message = response
     except ValueError:

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -1,7 +1,7 @@
 # chatgpt.py
 
 from epc.server import EPCServer
-# Hedge against breaking changes in chatgpt-wrapper
+# Hedge against breaking changes in chatgpt-wrapper >= 0.5.0
 try:
     from chatgpt_wrapper.config import Config
     import chatgpt_wrapper.constants as constants
@@ -51,7 +51,7 @@ def query(query, backend="chatgpt-browser", model="default"):
                f"Options are: 'chatgpt-browser', 'chatgpt-api'.")
 
     response = bot.ask(query)
-    # Hedge against more breaking changes in chatgpt-wrapper
+    # Hedge against more breaking changes in chatgpt-wrapper >= 0.5.0
     try:
         success, response, message = response
     except ValueError:

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -18,8 +18,7 @@ def query(query):
     global bot
     if bot is None:
         config = Config()
-        config.load_from_file()
-        config.set("browser.debug", False)
+        config.set("backend", "chatgpt-browser")
         bot = ChatGPT(config)
         bot.launch_browser()
 

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -2,11 +2,13 @@
 
 import pkg_resources
 from epc.server import EPCServer
-from chatgpt_wrapper import ChatGPT
-
-MIN_BREAKCHANGE_VERSION = "0.5.0"
-IS_BREAKING_CHANGE = pkg_resources.get_distribution("ChatGPT").parsed_version \
-                     >= pkg_resources.parse_version(MIN_BREAKCHANGE_VERSION)
+# Hedge against breaking changes in chatgpt-wrapper
+try:
+    from chatgpt_wrapper import ChatGPT
+    from chatgpt_wrapper.config import Config
+except ImportError:
+    from chatgpt_wrapper.backends.browser.chatgpt import ChatGPT
+    from chatgpt_wrapper.core.config import Config
 
 server = EPCServer(('localhost', 0))
 bot = None
@@ -15,12 +17,19 @@ bot = None
 def query(query):
     global bot
     if bot is None:
-        bot = ChatGPT()
+        config = Config()
+        config.load_from_file()
+        config.set("browser.debug", False)
+        bot = ChatGPT(config)
+        bot.launch_browser()
+
+    # Hedge against more breaking changes in chatgpt-wrapper
     response = bot.ask(query)
-    if IS_BREAKING_CHANGE:
-        # the return values have changed since 0.5.0
-        # https://github.com/mmabrouk/chatgpt-wrapper/commit/bc13f3dfc838aaa9299a5137723718081acd8eac#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21
+    try:
         success, response, message = response
+    except ValueError:
+        pass
+
     return response
 
 server.print_port()


### PR DESCRIPTION
Fix for #38.  Related: #42.  Builds on #46.

Allow user to set `chatgpt-backend` and `chatgpt-model` variables to change the backend and model respectively used by `chatgpt-wrapper`.

Sample Doom Emacs config:

```lisp
(setenv "OPENAI_API_KEY" (string-trim (shell-command-to-string "pass show openai_api_key")))
(use-package! chatgpt
  :defer t
  :config
  (unless (boundp 'python-interpreter)
    (defvaralias 'python-interpreter 'python-shell-interpreter))
  (setq chatgpt-repo-path (expand-file-name "straight/repos/ChatGPT.el/" doom-local-dir))
  (setq chatgpt-backend "chatgpt-api")
  (setq chatgpt-model "default")
  (set-popup-rule! (regexp-quote "*ChatGPT*")
    :side 'bottom :size .5 :ttl nil :quit t :modeline nil)
  :init
  (map! :leader
      (:prefix-map ("a" . "applications")
       (:prefix ("c" . "chatgpt")
        :desc "ChatGPT Query" "q" #'chatgpt-query
        :desc "ChatGPT Reset" "r" #'chatgpt-reset)))
  :bind ("C-c q" . chatgpt-query-stream)
)
```

Possible values for `chatgpt-backend`: `chatgpt-browser`, `chatgpt-api`.

Possible values for `chatgpt-model` when using `chatgpt-browser` backend: `default`, `legacy-paid`, `legacy-free`, `gpt4`.

Possible values for `chatgpt-model` when using `chatgpt-api` backend: `default`, `turbo`, `turbo-0301`, `gpt4`, `gpt4-0314`, `gpt4-32k`, `gpt4-32k-0314`.

These are based on the values specified in [constants.py](https://github.com/mmabrouk/chatgpt-wrapper/blob/main/chatgpt_wrapper/core/constants.py) from `chatgpt-wrapper`.
