### PR TITLE
Update README to use correct version of `chatgpt-wrapper`

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,7 +14,7 @@ OpenAI just released its [[https://openai.com/blog/introducing-chatgpt-and-whisp
 #+begin_src shell
 pip install sexpdata==0.0.3
 pip install epc
-pip install git+https://github.com/mmabrouk/chatgpt-wrapper
+pip install git+https://github.com/mmabrouk/chatgpt-wrapper@v0.11.7
 chatgpt install
 #+end_src
 


### PR DESCRIPTION
`chatgpt-wrapper` made some breaking changes (in particular, changing the name of the module to `lwe` from `chatgpt_wrapper`). As a temporary fix, we can just make sure to install the older version of the wrapper.