### PR TITLE
breaking fix of chatgpt.py to ApiBackend from ChatCPT

### DIFF
--- a/chatgpt.py
+++ b/chatgpt.py
@@ -2,7 +2,6 @@
 import pkg_resources
 from epc.server import EPCServer
 from lwe import ApiBackend
-from lwe.core.config import Config
 
 server = EPCServer(('localhost', 0))
 bot = None

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -1,12 +1,8 @@
 # chatgpt.py
-
 import pkg_resources
 from epc.server import EPCServer
-from chatgpt_wrapper import ChatGPT
-
-MIN_BREAKCHANGE_VERSION = "0.5.0"
-IS_BREAKING_CHANGE = pkg_resources.get_distribution("ChatGPT").parsed_version \
-                     >= pkg_resources.parse_version(MIN_BREAKCHANGE_VERSION)
+from lwe import ApiBackend
+from lwe.core.config import Config
 
 server = EPCServer(('localhost', 0))
 bot = None
@@ -15,13 +11,11 @@ bot = None
 def query(query):
     global bot
     if bot is None:
-        bot = ChatGPT()
-    response = bot.ask(query)
-    if IS_BREAKING_CHANGE:
-        # the return values have changed since 0.5.0
-        # https://github.com/mmabrouk/chatgpt-wrapper/commit/bc13f3dfc838aaa9299a5137723718081acd8eac#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21
-        success, response, message = response
-    return response
+        bot = ApiBackend()
+    success, response, message = bot.ask(query)
+    if success:
+        return response
+    return message
 
 server.print_port()
 server.serve_forever()


### PR DESCRIPTION
The API to the chatgpt_wrapper has changed: 

https://github.com/mmabrouk/chatgpt-wrapper#python

https://github.com/mmabrouk/chatgpt-wrapper/blob/593cd6f832b92eaf3332630c825c17d7a0510902/lwe/backends/api/backend.py#L25

When I tried installing this it failed to work because I would get the response:

```sh
epc:start-server: Server may raise an error. Use "M-x epc:pop-to-last-server-process-buffer RET" to see full traceback:
Traceback (most recent call last):
  File "/Users/akmb2/.emacs.d/.local/straight/repos/ChatGPT.el/chatgpt.py", line 4, in <module>
    from chatgpt_wrapper import ChatGPT
ModuleNotFoundError: No module named 'chatgpt_wrapper'
```

After some debugging, I determined that APIBackend is the suggested method to use ChatGPT for the updated package. I do not know when this was changed. 

I remove some of the previous checks because the import will fail if there is an old chatgpt_wrapper version.