### PR TITLE
Wrapper updates and other sanitation

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,8 +74,8 @@ In ~config.el~ ,
 (use-package! chatgpt
   :defer t
   :config
-  (unless (boundp 'python-interpreter)
-    (defvaralias 'python-interpreter 'python-shell-interpreter))
+  (unless (boundp 'chatgpt-python-interpreter)
+    (defvaralias 'chatgpt-python-interpreter 'python-shell-interpreter))
   (setq chatgpt-repo-path (expand-file-name "straight/repos/ChatGPT.el/" doom-local-dir))
   (set-popup-rule! (regexp-quote "*ChatGPT*")
     :side 'bottom :size .5 :ttl nil :quit t :modeline nil)
@@ -98,7 +98,7 @@ in the shell.
 - For most scenarios, the reliable method is ~pkill ms-playwright/firefox && chatgpt install~ to reauthenticate yourself.
 - Also try M-x chatgpt-reset.
 - If for some reason the ellipses keep blinking, try M-x chatgpt-stop.
-- Make sure you have python installed, and ~python-interpreter~ is set (most likely set it to "python" or "python3").
+- Make sure you have python installed, and ~chatgpt-python-interpreter~ is set (most likely set it to "python" or "python3").
 - If none of these methods work, please submit an [[https://github.com/joshcho/ChatGPT.el/issues/new][issue]].
 
 ** Customization

--- a/README.org
+++ b/README.org
@@ -115,6 +115,18 @@ Customize ~chatgpt-query-format-string-map~ for your own types.
                                         ("my-custom-type" . "My custom prompt.\n\n%s")))
 #+end_src
 
+~chatgpt-ensure-pip-install~
+
+Whether to automatically install the python chatgpt-wrapper package using
+pip if not detected in default ~pip list~. You might want to set this to
+~nil~ if you’re providing a custom ~chatgpt-python-interpreter~ (that
+points to a dedicated Python virtualenv for chatgpt-wrapper, for example).
+
+#+begin_src emacs-lisp
+(setq chatgpt-ensure-pip-install nil)
+#+end_src
+
+
 ** Misc.
 - Don't use "custom" as a type. It's reserved for custom prepend string through minibuffer.
 - See [[https://github.com/suonlight/ob-chatgpt][ob-chatgpt]] which builds on top of ChatGPT.el.

--- a/README.org
+++ b/README.org
@@ -17,8 +17,9 @@ pip install epc
 pip install git+https://github.com/mmabrouk/chatgpt-wrapper
 #+end_src
 
+NOTE: If you encounter any problems with chatgpt-wrapper, please submit an issue or see [[https://github.com/mmabrouk/chatgpt-wrapper][chatgpt-wrapper]].
 
-NOTE: If you encounter any problems, please submit an issue or see [[https://github.com/mmabrouk/chatgpt-wrapper][chatgpt-wrapper]].
+Set the OPENAI_API_KEY environment variable to [[https://platform.openai.com/account/api-keys][your API key]].
 
 *** [[https://github.com/radian-software/straight.el][Straight]]
 #+begin_src emacs-lisp

--- a/README.org
+++ b/README.org
@@ -7,14 +7,16 @@
 
 ** Installation
 *** Dependency
+
+Install the Python library that our Python helper program needs to be able
+to query ChatGPT:
+
 #+begin_src shell
 pip install sexpdata==0.0.3
 pip install epc
 pip install git+https://github.com/mmabrouk/chatgpt-wrapper
-chatgpt install
 #+end_src
 
-This will prompt you to log in with your browser.
 
 NOTE: If you encounter any problems, please submit an issue or see [[https://github.com/mmabrouk/chatgpt-wrapper][chatgpt-wrapper]].
 

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -72,6 +72,10 @@ might want to set this to `nil' if you're providing a custom
 `chatgpt-python-interpreter' (that points to a dedicated Python
 virtualenv for chatgpt-wrapper, for example).")
 
+(defcustom chatgpt-python-interpreter nil
+  "Path to Python interpreter that has a working chatgpt-wrapper
+package installed.")
+
 (defvar chatgpt-process nil
   "The ChatGPT process.")
 
@@ -100,9 +104,12 @@ function."
     (chatgpt-login))
   (when (null chatgpt-repo-path)
     (error "chatgpt-repo-path is nil. Please set chatgpt-repo-path as specified in joshcho/ChatGPT.el"))
-  (setq chatgpt-process (epc:start-epc python-interpreter (list (expand-file-name
-                                                                 (format "%schatgpt.py"
-                                                                         chatgpt-repo-path)))))
+  (setq chatgpt-process (epc:start-epc (if chatgpt-python-interpreter
+                                           (expand-file-name chatgpt-python-interpreter)
+                                         python-interpreter)
+                                       (list (expand-file-name
+                                              (format "%schatgpt.py"
+                                                      chatgpt-repo-path)))))
   (with-current-buffer (get-buffer-create "*ChatGPT*")
     (visual-line-mode 1))
   (message "ChatGPT initialized."))

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -65,6 +65,13 @@
   :type 'string
   :group 'chatgpt)
 
+(defcustom chatgpt-ensure-pip-install t
+  "Whether to automatically install the python chatgpt-wrapper
+package using pip if not detected in default `pip list'. You
+might want to set this to `nil' if you're providing a custom
+`chatgpt-python-interpreter' (that points to a dedicated Python
+virtualenv for chatgpt-wrapper, for example).")
+
 (defvar chatgpt-process nil
   "The ChatGPT process.")
 
@@ -86,7 +93,8 @@ successful.
 If ChatGPT server is not initialized, 'chatgpt-query' calls this
 function."
   (interactive)
-  (when (equal (shell-command-to-string "pip list | grep chatGPT") "")
+  (when (and chatgpt-ensure-pip-install
+             (equal (shell-command-to-string "pip list | grep chatGPT") ""))
     (shell-command "pip install git+https://github.com/mmabrouk/chatgpt-wrapper")
     (message "chatgpt-wrapper installed through pip.")
     (chatgpt-login))

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -23,9 +23,9 @@
   :prefix "chatgpt-"
   :group 'ai)
 
-(defcustom chatgpt-backend "chatgpt-browser"
-  "The backend for ChatGPT.el / chatgpt-wrapper (Options: 'chatgpt-browser',
-'chatgpt-api'. Default: 'chatgpt-browser'."
+(defcustom chatgpt-backend "browser"
+  "The backend for ChatGPT.el / chatgpt-wrapper (Options: 'browser',
+'api'. Default: 'browser'."
   :type 'string
   :group 'chatgpt)
 

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -106,6 +106,8 @@ function."
     (chatgpt-login))
   (when (null chatgpt-repo-path)
     (error "chatgpt-repo-path is nil. Please set chatgpt-repo-path as specified in joshcho/ChatGPT.el"))
+  (unless (getenv "OPENAI_API_KEY")
+    (error "Please set the environment variable \"OPENAI_API_KEY\" to your API key"))
   (setq chatgpt-process (epc:start-epc (if chatgpt-python-interpreter
                                            (expand-file-name chatgpt-python-interpreter)
                                          python-interpreter)

--- a/chatgpt.el
+++ b/chatgpt.el
@@ -23,9 +23,11 @@
   :prefix "chatgpt-"
   :group 'ai)
 
-(defcustom chatgpt-backend "browser"
-  "The backend for ChatGPT.el / chatgpt-wrapper (Options: 'browser',
-'api'. Default: 'browser'."
+(defcustom chatgpt-backend "api"
+  "The backend for ChatGPT.el / chatgpt-wrapper (Options:
+'api'. Default: 'api'.) Note that 'browser' was previously a
+valid option for this variable, but has been deprecated. Users
+should move to the 'api' backend."
   :type 'string
   :group 'chatgpt)
 
@@ -246,6 +248,8 @@ response.
 This function is intended to be called internally by the
 `chatgpt-query' function, and should not be called directly by
 users."
+  (when (string= "browser" chatgpt-backend)
+    (error "The 'browser' backend is deprecated. Please set chatgpt-backend to 'api'."))
   (unless chatgpt-process
     (chatgpt-init))
   (let ((saved-id (cl-incf chatgpt-id)))

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -2,7 +2,6 @@
 
 from epc.server import EPCServer
 from lwe.backends.api.backend import ApiBackend
-from lwe.backends.browser.backend import BrowserBackend
 from lwe.core.config import Config
 
 server = EPCServer(("localhost", 0))
@@ -10,23 +9,20 @@ bot = None
 
 
 @server.register_function
-def query(query, backend="browser", model="default"):
+def query(query, backend="api", model="default"):
     global bot
     if bot is None:
         config = Config()
-        if backend == "browser":
-            config.set("backend", backend)
-            config.set("chat.model", model)
-            bot = BrowserBackend(config)
-            bot.launch_browser()
-        elif backend == "api":
+        if backend == "api":
             config.set("backend", backend)
             config.set("chat.model", model)
             bot = ApiBackend(config)
+        elif backend == "browser":
+            return "The 'browser' backend is deprecated. Please switch to 'api'."
         else:
             return (
                 f"ChatGPT.el: Unknown chatgpt-wrapper backend: '{backend}'. "
-                f"Options are: 'browser', 'api'."
+                f"Options are: 'api'."
             )
 
     response = bot.ask(query)

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -1,64 +1,42 @@
 # chatgpt.py
-import pkg_resources
-from lwe import ApiBackend
-from epc.server import EPCServer
-# Hedge against breaking changes in chatgpt-wrapper >= 0.5.0
-try:
-    from chatgpt_wrapper.config import Config
-    import chatgpt_wrapper.constants as constants
-except ImportError:
-    from chatgpt_wrapper.core.config import Config
-    import chatgpt_wrapper.core.constants as constants
 
-server = EPCServer(('localhost', 0))
+from epc.server import EPCServer
+from lwe.backends.api.backend import ApiBackend
+from lwe.backends.browser.backend import BrowserBackend
+from lwe.core.config import Config
+
+server = EPCServer(("localhost", 0))
 bot = None
 
+
 @server.register_function
-def query(query, backend="chatgpt-browser", model="default"):
+def query(query, backend="browser", model="default"):
     global bot
     if bot is None:
         config = Config()
-        chatgpt_wrapper_browser_models = list(constants.RENDER_MODELS.keys())
-        chatgpt_wrapper_api_models = list(
-            constants.OPENAPI_CHAT_RENDER_MODELS.keys())
-        if backend == "chatgpt-browser":
+        if backend == "browser":
             config.set("backend", backend)
-            if model not in chatgpt_wrapper_browser_models:
-                return (f"ChatGPT.el: Unknown chatgpt-wrapper model '{model}' "
-                   f"for '{backend}' backend. "
-                   f"Options are: {chatgpt_wrapper_browser_models}.")
             config.set("chat.model", model)
-            # Hedge against breaking changes in chatgpt-wrapper >= 0.7.0
-            try:
-                from chatgpt_wrapper import ChatGPT
-            except ImportError:
-                from chatgpt_wrapper.backends.browser.chatgpt import ChatGPT
-            bot = ChatGPT(config)
+            bot = BrowserBackend(config)
             bot.launch_browser()
-        elif backend == "chatgpt-api":
+        elif backend == "api":
             config.set("backend", backend)
-            if model not in chatgpt_wrapper_api_models:
-                return (f"ChatGPT.el: Unknown chatgpt-wrapper model '{model}' "
-                   f"for '{backend}' backend. "
-                   f"Options are: {chatgpt_wrapper_api_models}.")
             config.set("chat.model", model)
-            # NOTE: This will not retain conversation history in its current
-            # form.
-            # See: https://github.com/mmabrouk/chatgpt-wrapper/issues/285
-            from chatgpt_wrapper import OpenAIAPI
-            bot = OpenAIAPI(config)
+            bot = ApiBackend(config)
         else:
-            return (f"ChatGPT.el: Unknown chatgpt-wrapper backend: '{backend}'. "
-               f"Options are: 'chatgpt-browser', 'chatgpt-api'.")
+            return (
+                f"ChatGPT.el: Unknown chatgpt-wrapper backend: '{backend}'. "
+                f"Options are: 'browser', 'api'."
+            )
 
     response = bot.ask(query)
-    # Hedge against more breaking changes in chatgpt-wrapper >= 0.5.0
     try:
         success, response, message = response
     except ValueError:
         pass
 
     return response
+
 
 server.print_port()
 server.serve_forever()


### PR DESCRIPTION
This PR contains a few fixes and improvements:

- Pulled in #52 (preserving authorship) and fixed merge conflicts (cc: @ncaq). This patch is necessary to keep up with updates from chatgpt-wrapper, which has not only changed their API, but also deprecated support for the 'browser' backend. The stop-gap of #53 is not enough.
- Add setting to avoid automatically running `pip install`. Although IMO we should just remove the automatic `pip install` altogether. Installing Python packages is the kind of thing the user should do themselves (and we already have instructions for that in the README) since an automatic installation could end up adding packages to an unexpected location, like the user's system python site packages directory. Let me know if you're okay with removing it altogether and I'll rework the patch to do that instead of adding this new setting.
- Renamed `python-interpreter` to `chatgpt-python-interpreter` (for "namespacing").
- Check that the user has set their OPENAI_API_KEY environment variable.